### PR TITLE
Add rate-limiting, enabled by default to 600/min

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Events include:
 ---------------------------------------
 
 ### osu! API
-More information on API returns and how some parameters work can be found at the [official osu! API GitHub wiki page](https://github.com/ppy/osu-api/wiki). 
+More information on API returns and how some parameters work can be found at the [official osu! API GitHub wiki page](https://github.com/ppy/osu-api/wiki).
 #### Main functions
 (Any argument not stated as optional should be required)
 
@@ -71,7 +71,7 @@ var osuApi = new Osu.api({
 ```
 Get started by requiring the module and defining your API key.
 
-(Another variable able to be passed is `uri`, which is set default to `https://osu.ppy.sh/api`. This can be set to elsewhere if it changes in the future)
+You can also pass other variables such as `uri`, which is set default to `https://osu.ppy.sh/api`, and `reqsPerMinute` which is set default to 600. Set `reqsPerMinute` to null to disable the rate-limiter.
 
 ##### raw
 ```javascript

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,17 +1,21 @@
 var Promise = require('promise');
 var extend = require('xtend'); // Use simple extend module because I'm lazy to write my own
+var RateLimiter = require('limiter').RateLimiter;
 
 function OsuApi (options) {
   // Bunch of default settings
   var settings = {
     apiUri: 'https://osu.ppy.sh/api',
-    apiKey: null
+    apiKey: null,
+    reqsPerMinute: 600
   };
 
   // "Extend" the user's ones in
   settings = extend(settings, options);
 
   this.settings = settings;
+  if(settings.reqsPerMinute)
+    this.limiter = new RateLimiter(settings.reqsPerMinute, 'minute');
 }
 
 OsuApi.prototype.request = function(endpoint, params, cb) {

--- a/lib/api/request.js
+++ b/lib/api/request.js
@@ -8,7 +8,7 @@ function jsRequest(osu, endpoint, params) { // Raw by JavaScript object. Main ba
   var options = {k: osu.settings.apiKey};
   options = extend(options, params);
 
-  return new Promise(function(resolve, reject) {
+  function callApi(resolve, reject) {
     request({baseUrl: osu.settings.apiUri, uri: endpoint, qs: options}, function (err, response, body) {
       if (err) reject(err);
       else {
@@ -17,6 +17,15 @@ function jsRequest(osu, endpoint, params) { // Raw by JavaScript object. Main ba
         else resolve(body);
       }
     });
+  }
+
+  return new Promise(function(resolve, reject) {
+    if(osu.settings.reqsPerMinute)
+      osu.limiter.removeTokens(1, function() {
+        callApi(resolve, reject);
+      });
+    else
+      callApi(resolve, reject);
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "irc": "^0.4.0",
+    "limiter": "^1.1.0",
     "promise": "^7.1.1",
     "request": "^2.61.0",
     "xtend": "^4.0.0"


### PR DESCRIPTION
I wasn't sure on how to implement it at `lib/api/request.js`'s level, it seems to be the best in my mind. Notice that I didn't put `callApi` outside of `jsRequest` to not have to pass more vars.

I tried to follow your coding style better this time, and updated documentation too.