### PR TITLE
Fix parsing of `pass` and `perfect`

### DIFF
--- a/lib/struct/MultiScore.js
+++ b/lib/struct/MultiScore.js
@@ -15,7 +15,7 @@ class MultiScore extends Score {
         super(data);
         this.slot = Number(data.slot);
         this.team = data.team === '0' ? null : Number(data.team);
-        this.pass = !!data.pass;
+        this.pass = !!Number(data.pass);
     }
 }
 

--- a/lib/struct/Score.js
+++ b/lib/struct/Score.js
@@ -22,7 +22,7 @@ class Score {
         this.maxCombo = Number(data.maxcombo);
         this.countKatu = Number(data.countkatu);
         this.countGeki = Number(data.countgeki);
-        this.perfect = !!data.perfect;
+        this.perfect = !!Number(data.perfect);
     }
 }
 


### PR DESCRIPTION
In the JSON response, these are strings ``"0"`` or ``"1"``, which are both truthy,
and must be converted to numbers for proper truthiness.