### PR TITLE
Handle API times as UTC

### DIFF
--- a/lib/struct/Beatmap.js
+++ b/lib/struct/Beatmap.js
@@ -34,8 +34,8 @@
 class Beatmap {
     constructor(data) {
         this.approved = Number(data.approved);
-        this.approvedDate = new Date(data.approved_date + ' GMT+0800');
-        this.lastUpdate = new Date(data.last_update + ' GMT+0800');
+        this.approvedDate = new Date(data.approved_date + ' GMT');
+        this.lastUpdate = new Date(data.last_update + ' GMT');
         this.artist = data.artist;
         this.id = Number(data.beatmap_id);
         this.setId = Number(data.beatmapset_id);

--- a/lib/struct/BeatmapScore.js
+++ b/lib/struct/BeatmapScore.js
@@ -19,7 +19,7 @@ class BeatmapScore extends Score {
         this.username = data.username;
         this.enabledMods = Number(data.enabled_mods);
         this.userId = Number(data.user_id);
-        this.date = new Date(data.date + ' GMT+0800');
+        this.date = new Date(data.date + ' GMT');
         this.rank = data.rank;
         this.pp = Number(data.pp);
     }

--- a/lib/struct/MultiGame.js
+++ b/lib/struct/MultiGame.js
@@ -18,8 +18,8 @@ const MultiScore = require('./MultiScore');
 class MultiGame {
     constructor(data) {
         this.id = Number(data.game_id);
-        this.startTime = new Date(data.start_time + ' GMT+0800');
-        this.endTime = new Date(data.end_time + ' GMT+0800');
+        this.startTime = new Date(data.start_time + ' GMT');
+        this.endTime = new Date(data.end_time + ' GMT');
         this.beatmapId = Number(data.beatmap_id);
         this.playMode = Number(data.play_mode);
         this.scoringType = Number(data.scoring_type);

--- a/lib/struct/MultiMatch.js
+++ b/lib/struct/MultiMatch.js
@@ -11,7 +11,7 @@ class MultiMatch {
     constructor(data) {
         this.id = Number(data.match_id);
         this.name = data.name;
-        this.startTime = new Date(data.start_time + ' GMT+0800');
+        this.startTime = new Date(data.start_time + ' GMT');
     }
 
     get matchId() { return this.id; }

--- a/lib/struct/UserEvent.js
+++ b/lib/struct/UserEvent.js
@@ -14,7 +14,7 @@ class UserEvent {
         this.displayHtml = data.display_html;
         this.beatmapId = Number(data.beatmap_id);
         this.beatmapSetId = Number(data.beatmapset_id);
-        this.date = new Date(data.date + ' GMT+0800');
+        this.date = new Date(data.date + ' GMT');
         this.epicfactor = Number(data.epicfactor);
     }
 }


### PR DESCRIPTION
peppy fixed the API a while ago to return date & times as UTC, instead of UTC+8.