### PR TITLE
BeatmapsComponent: Add mods support

### DIFF
--- a/lib/components/BeatmapsComponent.js
+++ b/lib/components/BeatmapsComponent.js
@@ -2,7 +2,8 @@
 
 const Component = require('./Component')
     , ApiConstants = require('../Constants').API
-    , Beatmap = require('../struct/Beatmap');
+    , Beatmap = require('../struct/Beatmap')
+    , Mods = require('../enum/Mods');
 
 /**
  * Beatmap-related API component
@@ -13,7 +14,7 @@ const Component = require('./Component')
  *     .then(console.log);
  */
 class BeatmapsComponent extends Component {
-    _get(letter, id, mode, limit, includeConverts, lookupType) {
+    _get(letter, id, mode, limit, includeConverts, lookupType, mods) {
         let options = {};
         options[letter] = id;
         if (mode !== undefined)
@@ -25,6 +26,11 @@ class BeatmapsComponent extends Component {
         if (lookupType !== undefined)
             options.type = lookupType;
 
+        // Include mods and filter out mods that return null difficulty values
+        if (mods !== undefined)
+            options.mods = mods & (Mods.DoubleTime | Mods.Easy | Mods.HalfTime | Mods.HardRock
+                | Mods.Key4 | Mods.Key5 | Mods.Key6 | Mods.Key7 | Mods.Key8 | Mods.Key9);
+
         return this.api.requester.get(ApiConstants.BEATMAPS_GET, options, true, true, Beatmap);
     }
 
@@ -34,10 +40,11 @@ class BeatmapsComponent extends Component {
      * @param {Mode} [mode] The gamemode of maps to find.
      * @param {Number} [limit] The limit of maps to find.
      * @param {Converts} [includeConverts] If converts should be included in the lookup.
+     * @param {Mods} [mods] Applied mods.
      * @return {Promise<Object[]|Beatmap[]>} The object array from the API, or Beatmap object array if parsing is enabled.
      */
-    getBySetId(setId, mode, limit, includeConverts) {
-        return this._get('s', setId, mode, limit, includeConverts);
+    getBySetId(setId, mode, limit, includeConverts, mods) {
+        return this._get('s', setId, mode, limit, includeConverts, undefined, mods);
     }
 
     /**
@@ -46,10 +53,11 @@ class BeatmapsComponent extends Component {
      * @param {Mode} [mode] The gamemode of maps to find.
      * @param {Number} [limit] The limit of maps to find.
      * @param {Converts} [includeConverts] If converts should be included in the lookup.
+     * @param {Mods} [mods] Applied mods.
      * @return {Promise<Object[]|Beatmap[]>} The object array from the API, or Beatmap object array if parsing is enabled.
      */
-    getByBeatmapId(beatmapId, mode, limit, includeConverts) {
-        return this._get('b', beatmapId, mode, limit, includeConverts);
+    getByBeatmapId(beatmapId, mode, limit, includeConverts, mods) {
+        return this._get('b', beatmapId, mode, limit, includeConverts, undefined, mods);
     }
 
     /**
@@ -59,10 +67,11 @@ class BeatmapsComponent extends Component {
      * @param {Number} [limit] The limit of maps to find.
      * @param {Converts} [includeConverts] If converts should be included in the lookup.
      * @param {LookupType} [lookupType] The type of lookup of the user.
+     * @param {Mods} [mods] Applied mods.
      * @return {Promise<Object[]|Beatmap[]>} The object array from the API, or Beatmap object array if parsing is enabled.
      */
-    getByUser(user, mode, limit, includeConverts, lookupType) {
-        return this._get('u', user, mode, limit, includeConverts, lookupType);
+    getByUser(user, mode, limit, includeConverts, lookupType, mods) {
+        return this._get('u', user, mode, limit, includeConverts, lookupType, mods);
     }
 
     /**
@@ -71,10 +80,11 @@ class BeatmapsComponent extends Component {
      * @param {Mode} [mode] The gamemode of maps to find.
      * @param {Number} [limit] The limit of maps to find.
      * @param {Converts} [includeConverts] If converts should be included in the lookup.
+     * @param {Mods} [mods] Applied mods.
      * @return {Promise<Object[]|Beatmap[]>} The object array from the API, or Beatmap object array if parsing is enabled.
      */
-    getByBeatmapHash(hash, mode, limit, includeConverts) {
-        return this._get('h', hash, mode, limit, includeConverts);
+    getByBeatmapHash(hash, mode, limit, includeConverts, mods) {
+        return this._get('h', hash, mode, limit, includeConverts, undefined, mods);
     }
 }
 


### PR DESCRIPTION
Implements mods support in beatmap queries, as per recent API changes. See ppy/osu-api#126.