### PR TITLE
Handle cases where osu!api is failing

### DIFF
--- a/lib/Requester.js
+++ b/lib/Requester.js
@@ -72,6 +72,10 @@ class Requester {
 
         return new Promise((resolve, reject) => {
             driver.get(url, requestOptions, res => {
+                if(res.statusCode >= 500) {
+                    return reject(new OsuApiError("Internal server error."));
+                }
+
                 let data = '';
                 res.on('data', chunk => data += chunk);
                 res.once('end', () => {


### PR DESCRIPTION
When the osu!api is failing, it returns a generic HTML error page, which
causes nodesu to fail when trying to parse it as JSON. This commit makes
nodesu handle 5xx errors as expected.

I have seen the API return 503 and 525 error codes, don't know about others. Will update this PR once (if) the API fails again and this is properly tested.